### PR TITLE
remove Archive::Tar and add recommends Archive::Zip

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,6 @@ author        'Adam Kennedy <adamk@cpan.org>';
 perl_version  '5.006';
 all_from      'lib/Module/Install.pm';
 
-requires      'Archive::Tar'        => '1.44';
 requires      'Devel::PPPort'       => '3.16';
 requires      'ExtUtils::Install'   => '1.52';
 requires      'ExtUtils::MakeMaker' => '6.59';
@@ -39,6 +38,8 @@ requires      'YAML::Tiny'          => '1.38';
 
 test_requires 'Test::Harness'       => '3.13';
 test_requires 'Test::More'          => '0.86';
+
+recommends    'Archive::Zip'        => '1.37';
 
 # Remove some extra test files
 clean_files( qw{ t/Foo } );


### PR DESCRIPTION
see lib/Module/Install/PAR.pm

``` text
kevin@billy:~/GitHub/Module-Install$ grep -r 'Archive::' .
./Makefile.PL:requires      'Archive::Tar'        => '1.44';
./lib/Module/Install/PAR.pm:    if ( eval { require Archive::Zip; 1 } ) {
./lib/Module/Install/PAR.pm:        my $zip = Archive::Zip->new;
./lib/Module/Install/PAR.pm:        return unless $zip->read($file) == Archive::Zip::AZ_OK()
./lib/Module/Install/PAR.pm:                  and $zip->extractTree('', 'blib/') == Archive::Zip::AZ_OK();
./lib/Module/Install/PAR.pm:Could not extract .par archive because neither Archive::Zip nor a
./lib/Module/Install/PAR.pm:Archive::Zip.
```
