### PR TITLE
Apply patch from RT-89030

### DIFF
--- a/lib/Module/AutoInstall.pm
+++ b/lib/Module/AutoInstall.pm
@@ -344,22 +344,26 @@ sub install {
     my $i;    # used below to strip leading '-' from config keys
     my @config = ( map { s/^-// if ++$i; $_ } @{ +shift } );
 
-    my ( @modules, @installed );
-    while ( my ( $pkg, $ver ) = splice( @_, 0, 2 ) ) {
+	my ( @modules, @installed, @modules_to_upgrade );
+	while (my ($pkg, $ver) = splice(@_, 0, 2)) {
 
-        # grep out those already installed
-        if ( _version_cmp( _version_of($pkg), $ver ) >= 0 ) {
-            push @installed, $pkg;
-        }
-        else {
-            push @modules, $pkg, $ver;
-        }
-    }
+		# grep out those already installed
+		if (_version_cmp(_version_of($pkg), $ver) >= 0) {
+			push @installed, $pkg;
+			if ($UpgradeDeps) {
+				push @modules_to_upgrade, $pkg, $ver;
+			}
+		}
+		else {
+			push @modules, $pkg, $ver;
+		}
+	}
 
-    if ($UpgradeDeps) {
-        push @modules, @installed;
-        @installed = ();
-    }
+	if ($UpgradeDeps) {
+		push @modules, @modules_to_upgrade;
+		@installed          = ();
+		@modules_to_upgrade = ();
+	}
 
     return @installed unless @modules;  # nothing to do
     return @installed if _check_lock(); # defer to the CPAN shell


### PR DESCRIPTION
I recently ran into an issue with creating a bundle through Module::Install - when running "make upgradedeps" an error is thrown about versions not being numeric.

It appears to be caused by a difference between the shape of the contents of the arrays "@modules" and "@installed" in Module::AutoInstall::install.

Attached is a patch that appears to fix this for me - it simply creates an array suitable for @modules if $UpgradeDeps is set, and uses this for any/all upgrades.
