### PR TITLE
RT-62847

### DIFF
--- a/lib/Module/AutoInstall.pm
+++ b/lib/Module/AutoInstall.pm
@@ -114,7 +114,7 @@ sub import {
     print "*** $class version " . $class->VERSION . "\n";
     print "*** Checking for Perl dependencies...\n";
 
-    my $cwd = Cwd::cwd();
+    my $cwd = Cwd::getcwd();
 
     $Config = [];
 
@@ -614,7 +614,7 @@ sub _under_cpan {
     require Cwd;
     require File::Spec;
 
-    my $cwd  = File::Spec->canonpath( Cwd::cwd() );
+    my $cwd  = File::Spec->canonpath( Cwd::getcwd() );
     my $cpan = File::Spec->canonpath( $CPAN::Config->{cpan_home} );
 
     return ( index( $cwd, $cpan ) > -1 );

--- a/lib/Module/Install.pm
+++ b/lib/Module/Install.pm
@@ -155,10 +155,10 @@ END_DIE
 sub autoload {
 	my $self = shift;
 	my $who  = $self->_caller;
-	my $cwd  = Cwd::cwd();
+	my $cwd  = Cwd::getcwd();
 	my $sym  = "${who}::AUTOLOAD";
 	$sym->{$cwd} = sub {
-		my $pwd = Cwd::cwd();
+		my $pwd = Cwd::getcwd();
 		if ( my $code = $sym->{$pwd} ) {
 			# Delegate back to parent dirs
 			goto &$code unless $cwd eq $pwd;
@@ -238,7 +238,7 @@ sub new {
 
 	# ignore the prefix on extension modules built from top level.
 	my $base_path = Cwd::abs_path($FindBin::Bin);
-	unless ( Cwd::abs_path(Cwd::cwd()) eq $base_path ) {
+	unless ( Cwd::abs_path(Cwd::getcwd()) eq $base_path ) {
 		delete $args{prefix};
 	}
 	return $args{_self} if $args{_self};
@@ -337,7 +337,7 @@ sub find_extensions {
 		if ( $subpath eq lc($subpath) || $subpath eq uc($subpath) ) {
 			my $content = Module::Install::_read($subpath . '.pm');
 			my $in_pod  = 0;
-			foreach ( split //, $content ) {
+			foreach ( split /\n/, $content ) {
 				$in_pod = 1 if /^=\w/;
 				$in_pod = 0 if /^=cut/;
 				next if ($in_pod || /^=cut/);  # skip pod text

--- a/lib/Module/Install/Admin/Bundle.pm
+++ b/lib/Module/Install/Admin/Bundle.pm
@@ -2,7 +2,6 @@ package Module::Install::Admin::Bundle;
 
 use strict;
 use Module::Install::Base;
-use Module::CoreList;
 
 use vars qw{$VERSION @ISA};
 BEGIN {

--- a/lib/Module/Install/Admin/Manifest.pm
+++ b/lib/Module/Install/Admin/Manifest.pm
@@ -9,7 +9,7 @@ BEGIN {
 	@ISA     = qw{Module::Install::Base};
 }
 
-use Cwd;
+use Cwd ();
 use File::Spec;
 
 # XXX I really want this method in Module::Install::Admin::Makefile
@@ -93,7 +93,7 @@ sub _read_manifest {
 	my $manifest_path = '';
 	my $relative_path = '';
 	my @relative_dirs = ();
-	my $cwd = Cwd::cwd();
+	my $cwd = Cwd::getcwd();
 	my @cwd_dirs = File::Spec->splitdir($cwd);
 	while ( @cwd_dirs ) {
 		last unless -f File::Spec->catfile(@cwd_dirs, 'Makefile.PL');


### PR DESCRIPTION
I thought Makefile.PL on Module::Install is really slow so that I couldn't continue to use it, but by profiling I found that the bottleneck: Cwd::cwd(), which does `pwd`, instead of getcwd(3), and that Use of Cwd::getcwd() makes M::I significantly faster!
