### PR TITLE
keep test cleanups from failing on win32 by running faster than the file system

### DIFF
--- a/t/lib/Test.pm
+++ b/t/lib/Test.pm
@@ -189,8 +189,15 @@ sub run_makefile_pl {
 sub kill_dist {
 	my $dir = dir();
 	return 1 unless -d $dir;
+	windows_delay();
 	File::Remove::remove( \1, $dir );
+	windows_delay();
 	return -d $dir ? 0 : 1;
+}
+
+sub windows_delay {
+	return if $^O ne 'MSWin32';
+	select undef, undef, undef, 0.1;
 }
 
 sub supports_capture {


### PR DESCRIPTION
~~I would've preferred to use Time::HiRes, but decided not to risk dep issues.~~

The delays will allow the file system to release locks, and to remove the dir before checking if it's actually gone. Might still fail on exceptionally slow file systems.
