### PR TITLE
RT-92547 remove sub pototypes

### DIFF
--- a/lib/Module/Install.pm
+++ b/lib/Module/Install.pm
@@ -433,7 +433,7 @@ END_OLD
 
 # _version is for processing module versions (eg, 1.03_05) not
 # Perl versions (eg, 5.8.1).
-sub _version ($) {
+sub _version {
 	my $s = shift || 0;
 	my $d =()= $s =~ /(\.)/g;
 	if ( $d >= 2 ) {
@@ -449,12 +449,12 @@ sub _version ($) {
 	return $l + 0;
 }
 
-sub _cmp ($$) {
+sub _cmp {
 	_version($_[1]) <=> _version($_[2]);
 }
 
 # Cloned from Params::Util::_CLASS
-sub _CLASS ($) {
+sub _CLASS {
 	(
 		defined $_[0]
 		and

--- a/t/03_autoinstall.t
+++ b/t/03_autoinstall.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!perl
 
 use strict;
 BEGIN {
@@ -22,7 +22,7 @@ my @prompts = qw/y n n y y/;
 
 use ExtUtils::MakeMaker;
 sub ExtUtils::MakeMaker::WriteMakefile { $mm_args = {@_} }
-sub ExtUtils::MakeMaker::prompt ($;$) { return 'n' }
+sub ExtUtils::MakeMaker::prompt { return 'n' }
 
 # tiehandle trick to intercept STDOUT.
 sub PRINT     { my $self = shift; $$self .= join '', @_; }


### PR DESCRIPTION
~/GitHub/Module-Install$ grep -r -P '\Asub\s+[\w|:]+\s+(' .
./lib/Module/Install.pm:sub _version ($) {
./lib/Module/Install.pm:sub _cmp ($$) {
./lib/Module/Install.pm:sub _CLASS ($) {
./t/03_autoinstall.t:sub ExtUtils::MakeMaker::prompt ($;$) { return 'n' }
