### PR TITLE
Handle the urllist option when using CPAN

### DIFF
--- a/lib/Module/AutoInstall.pm
+++ b/lib/Module/AutoInstall.pm
@@ -536,7 +536,7 @@ sub _install_cpan {
     while ( my ( $opt, $arg ) = splice( @config, 0, 2 ) ) {
         ( $args{$opt} = $arg, next )
           if $opt =~ /^(?:force|notest)$/;    # pseudo-option
-        $CPAN::Config->{$opt} = $arg;
+        $CPAN::Config->{$opt} = $opt eq 'urllist' ? [$arg] : $arg;
     }
 
     if ($args{notest} && (not CPAN::Shell->can('notest'))) {


### PR DESCRIPTION
This is a local change that I've needed working with [Pinto](https://metacpan.org/pod/Pinto) and not wanting to maintain a fork I thought I'd push it upstream :smile:. Not sure of an appropriate way to test it but I'm hoping the change is sufficiently simple that it isn't necessary. Usage in a `Makefile.PL` postamble looks something like this:

``` shell
$(PERL) Makefile.PL --config=urllist,$(PINTO_URL)/$(BRANCH) --installdeps=...
```

Cheers,
Dan Brook
