### PR TITLE
Tests fail on Windows due to spurious CR characters

### DIFF
--- a/t/22_installdirs.t
+++ b/t/22_installdirs.t
@@ -28,7 +28,7 @@ END_DSL
 	ok(-f $file);
 	my $content = _read($file);
 	ok($content, 'file is not empty');
-	my ($installdirs) = $content =~ /^INSTALLDIRS\s*=\s*(.+)$/m;
+	my $installdirs = _extract_installdirs($content);
 	diag "INSTALLDIRS: $installdirs" if $ENV{TEST_VERBOSE};
 	ok( $installdirs eq '~/local/', 'correct INSTALLDIRS');
 	ok( kill_dist(), 'kill_dist' );
@@ -49,7 +49,7 @@ END_DSL
 	ok(-f $file);
 	my $content = _read($file);
 	ok($content, 'file is not empty');
-	my ($installdirs) = $content =~ /^INSTALLDIRS\s*=\s*(.+)$/m;
+	my $installdirs = _extract_installdirs($content);
 	diag "INSTALLDIRS: $installdirs" if $ENV{TEST_VERBOSE};
 	ok( $installdirs eq '~/local/', 'correct INSTALLDIRS');
 	ok( kill_dist(), 'kill_dist' );
@@ -71,7 +71,7 @@ END_DSL
 	ok(-f $file);
 	my $content = _read($file);
 	ok($content, 'file is not empty');
-	my ($installdirs) = $content =~ /^INSTALLDIRS\s*=\s*(.+)$/m;
+	my $installdirs = _extract_installdirs($content);
 	diag "INSTALLDIRS: $installdirs" if $ENV{TEST_VERBOSE};
 	ok( $installdirs eq '~/local/', 'correct INSTALLDIRS');
 	ok( kill_dist(), 'kill_dist' );
@@ -92,8 +92,14 @@ END_DSL
 	ok(-f $file);
 	my $content = _read($file);
 	ok($content, 'file is not empty');
-	my ($installdirs) = $content =~ /^INSTALLDIRS\s*=\s*(.+)$/m;
+	my $installdirs = _extract_installdirs($content);
 	diag "INSTALLDIRS: $installdirs" if $ENV{TEST_VERBOSE};
 	ok( $installdirs eq 'perl', 'correct INSTALLDIRS');
 	ok( kill_dist(), 'kill_dist' );
 }
+
+sub _extract_installdirs {
+	my ($installdirs) = $_[0] =~ /^INSTALLDIRS\s*=\s*([^\x0a\x0d]+)/m;
+	$installdirs;
+}
+

--- a/t/lib/Test.pm
+++ b/t/lib/Test.pm
@@ -7,6 +7,9 @@ use File::Path ();
 use Cwd;
 use Config;
 
+require ExtUtils::MakeMaker;
+my $eumm = eval $ExtUtils::MakeMaker::VERSION;
+
 use vars qw{$VERSION @ISA @EXPORT $DIST};
 BEGIN {
 	$VERSION = '1.14';
@@ -34,6 +37,9 @@ eval( $] >= 5.006 ? <<'END_NEW' : <<'END_OLD' ); die $@ if $@;
 sub _read {
 	local *FH;
 	open( FH, '<', $_[0] ) or die "open($_[0]): $!";
+	if (MM->os_flavor_is('Win32') and ($eumm >= 6.99_08)) {
+		binmode FH, ':raw';
+	}
 	my $string = do { local $/; <FH> };
 	close FH or die "close($_[0]): $!";
 	return $string;
@@ -42,6 +48,9 @@ END_NEW
 sub _read {
 	local *FH;
 	open( FH, "< $_[0]"  ) or die "open($_[0]): $!";
+	if ((MM->os_flavor_is('Win32') and ($eumm >= 6.99_08)) {
+		binmode FH, ':raw';
+	}
 	my $string = do { local $/; <FH> };
 	close FH or die "close($_[0]): $!";
 	return $string;
@@ -64,6 +73,9 @@ sub create_dist {
 
 	# Write the MANIFEST
 	open( MANIFEST, '>MANIFEST' ) or return 0;
+	if (MM->os_flavor_is('Win32') and ($eumm >= 6.99_08)) {
+		binmode MANIFEST, ':raw';
+	}
 	print MANIFEST $opt->{MANIFEST} || <<"END_MANIFEST";
 MANIFEST
 Makefile.PL
@@ -73,6 +85,9 @@ END_MANIFEST
 
 	# Write the configure script
 	open MAKEFILE_PL, '>Makefile.PL' or return 0;
+	if (MM->os_flavor_is('Win32') and ($eumm >= 6.99_08)) {
+		binmode MAKEFILE_PL, ':raw';
+	}
 	print MAKEFILE_PL $opt->{'Makefile.PL'} || <<"END_MAKEFILE_PL";
 use inc::Module::Install 0.81;
 name          '$DIST';
@@ -86,6 +101,9 @@ END_MAKEFILE_PL
 
 	# Write the module file
 	open MODULE, ">lib/$DIST.pm" or return 0;
+	if (MM->os_flavor_is('Win32') and ($eumm >= 6.99_08)) {
+		binmode MODULE, ':raw';
+	}
 	print MODULE $opt->{"lib/$DIST.pm"} || <<"END_MODULE";
 package $DIST;
 
@@ -147,6 +165,9 @@ sub add_file {
 	}
 
 	open FILE, "> $dist_file" or return 0;
+	if (MM->os_flavor_is('Win32') and ($eumm >= 6.99_08)) {
+		binmode FILE, ':raw';
+	}
 	print FILE $content;
 	close FILE;
 
@@ -204,7 +225,7 @@ sub supports_capture {
 	# stolen from ExtUtils::MakeMaker's test
 	use ExtUtils::MM;
 
-	# Unix, modern Windows and OS/2 from 5.005_54 up can handle 2>&1 
+	# Unix, modern Windows and OS/2 from 5.005_54 up can handle 2>&1
 	# This makes our failure diagnostics nicer to read.
 	return 1
 		if (MM->os_flavor_is('Unix') or
@@ -258,9 +279,6 @@ sub make {
 	chdir $home;
 	return $ret;
 }
-
-require ExtUtils::MakeMaker;
-my $eumm = eval $ExtUtils::MakeMaker::VERSION;
 
 sub author_makefile_re {
 	my $author=shift;


### PR DESCRIPTION
Given that both the tests and Module::Install have been around
for a while, my explanation for the failures is that the commit

https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/commit/cfabc28

to ExtUtils::MakeMaker is causing the problem.

Coming from that perspective, I conditionally applied binmode
':raw' to filehandles in t/lib/Test.pm. Tests in t/22_installdirs.t
were still failing after that, so I set the captures up to any CR/LF
characters.

This seems to work for now, although I have yet to test it elsehwere.