### PR TITLE
travis: Force Makefile.PL to be invoked independently.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ perl:
   - '5.12'
   - '5.10'
   - '5.8'
-
+install:
+  - perl Makefile.PL
+  - cpanm --quiet --installdeps --notest .


### PR DESCRIPTION
Because there are certain kinds of bugs in bootstrap that can surface,
having relevant output without tampering from cpanm is important.

And the cpanm logic ordinarily hides this error.

For instance, recently somebody used "suggests" in Makefile.PL, and the
tests failed to build without it being obvious why.

This fix exposed the error:

```
String found where operator expected at Makefile.PL line 49, near
"suggests      'CPANPLUS'"
  (Do you need to predeclare suggests?)
```