### PR TITLE
Replace broken EXAMPLES link with link to COOKBOOK/EXAMPLES

### DIFF
--- a/lib/Module/AutoInstall.pm
+++ b/lib/Module/AutoInstall.pm
@@ -1001,8 +1001,8 @@ option offered by B<ExtUtils::MakeMaker>.
 
 This module works best with the B<Module::Install> framework,
 a drop-in replacement for MakeMaker.  However, this module also
-supports F<Makefile.PL> files based on MakeMaker; see L</EXAMPLES>
-for instructions.
+supports F<Makefile.PL> files based on MakeMaker; see
+L<Module::Install/"COOKBOOK / EXAMPLES"> for instructions.
 
 Specifying C<installdeps_target;> instead of C<auto_install;> will not try to
 install dependencies when running C<make>, but only when running C<make


### PR DESCRIPTION
The link to the EXAMPLES section doesn't exist and it seems sensible to link
this to the COOKBOOK/EXAMPLES section of `Module::Install` as the
`Module::Install::Admin` docs do.