### PR TITLE
Only call mkpath() if there is a path to create

### DIFF
--- a/lib/Module/Install/Admin.pm
+++ b/lib/Module/Install/Admin.pm
@@ -129,7 +129,8 @@ sub copy {
 	my ($self, $from, $to) = @_;
 
 	my @parts = split('/', $to);
-	File::Path::mkpath([ join('/', @parts[ 0 .. $#parts-1 ])]);
+	File::Path::mkpath([ join('/', @parts[ 0 .. $#parts-1 ])])
+	  if @parts > 1;
 
 	chomp $to;
 


### PR DESCRIPTION
Older File::Path throws on `mkpath('')`, which in turn trips up t/33copy.t
(the tested paths are plain `a` and `b`)