### PR TITLE
first try fixing utf8 issues

### DIFF
--- a/lib/Module/Install.pm
+++ b/lib/Module/Install.pm
@@ -412,6 +412,8 @@ sub _readpod {
 	return $string;
 }
 
+use utf8;
+
 # Done in evals to avoid confusing Perl::MinimumVersion
 eval( $] >= 5.006 ? <<'END_NEW' : <<'END_OLD' ); die $@ if $@;
 sub _write {
@@ -419,6 +421,7 @@ sub _write {
 	open( FH, '>', $_[0] ) or die "open($_[0]): $!";
 	binmode FH;
 	foreach ( 1 .. $#_ ) {
+		utf8::encode($_[$_]) if $] >= 5.008001 && utf8::is_utf8($_[$_]);
 		print FH $_[$_] or die "print($_[0]): $!";
 	}
 	close FH or die "close($_[0]): $!";

--- a/lib/Module/Install.pm
+++ b/lib/Module/Install.pm
@@ -379,6 +379,7 @@ sub _read {
 	open( FH, '<', $_[0] ) or die "open($_[0]): $!";
 	binmode FH;
 	my $string = do { local $/; <FH> };
+	utf8::decode($string);
 	close FH or die "close($_[0]): $!";
 	return $string;
 }
@@ -421,7 +422,7 @@ sub _write {
 	open( FH, '>', $_[0] ) or die "open($_[0]): $!";
 	binmode FH;
 	foreach ( 1 .. $#_ ) {
-		utf8::encode($_[$_]) if $] >= 5.008001 && utf8::is_utf8($_[$_]);
+		utf8::encode($_[$_]);
 		print FH $_[$_] or die "print($_[0]): $!";
 	}
 	close FH or die "close($_[0]): $!";

--- a/t/20_authors_with_special_characters.t
+++ b/t/20_authors_with_special_characters.t
@@ -27,6 +27,7 @@ all_from      'lib/Foo.pm';
 WriteAll;
 END_DSL
 
+
 	ok( add_file(qw(lib Foo.pm), <<'END') );
 package Foo;
 1;
@@ -42,7 +43,7 @@ First 'Middle' Last
 
 \=cut
 END
-
+	
 	ok( build_dist(), 'build_dist' );
 	my $file = makefile();
 	ok(-f $file);
@@ -59,9 +60,11 @@ END
 	ok( kill_dist(), 'kill_dist' );
 }
 
+
 if ($] >= 5.008) {
-	eval "use utf8";
+	
 	SCOPE: {
+		no utf8;
 		ok( create_dist('Foo', { 'Makefile.PL' => <<"END_DSL" }), 'create_dist' );
 use inc::Module::Install 0.81;
 name          'Foo';
@@ -77,58 +80,66 @@ package Foo;
 1;
 \__END__
 
+\=encoding utf8
+
 \=head1 NAME
 
 Foo - Abstract
 
 \=head1 AUTHOR
 
-Olivier MenguE<eacute>
+Olivier Mengué
 
 \=cut
 END
-
+		
+		use utf8;
 		ok( build_dist(), 'build_dist' );
 		my $file = makefile();
 		ok(-f $file);
 		my $content = _read($file);
 		ok($content, 'file is not empty');
-    TODO: {
-      local $TODO = 'EUMM 7.00 fixed unicode but we have not' if $eumm gt '6.98';
-		  ok($content =~ author_makefile_re("Olivier Mengu\xE9"), 'has one author');
-    }
+	    TODO: {
+	    	local $TODO = 'EUMM 7.00 fixed unicode but we have not' if $eumm gt '6.98';
+		    ok($content =~ author_makefile_re("Olivier Mengué"), 'has one author');
+	    }
 		my $metafile = file('META.yml');
 		ok(-f $metafile);
 		my $meta = Parse::CPAN::Meta::LoadFile($metafile);
-		is_deeply($meta->{author}, [q(Olivier Mengu\xE9)]);
-		ok( kill_dist(), 'kill_dist' );
+		is_deeply($meta->{author}, [q(Olivier Mengué)]);
+		ok( kill_dist(), 'kill_dist' );		
 	}
 
 	SCOPE: {
+		no utf8;
 		ok( create_dist('Foo', { 'Makefile.PL' => <<"END_DSL" }), 'create_dist' );
+use utf8;
 use inc::Module::Install 0.81;
 name          'Foo';
 perl_version  '5.005';
 version       '0.01';
 license       'perl';
-author        "Olivier Mengu\xE9";
+author        "Olivier Mengué";
 all_from      'lib/Foo.pm';
 WriteAll;
 END_DSL
 
+		use utf8;
 		ok( build_dist(), 'build_dist' );
 		my $file = makefile();
 		ok(-f $file);
 		my $content = _read($file);
 		ok($content, 'file is not empty');
-    TODO: {
-      local $TODO = 'EUMM 7.00 fixed unicode but we have not' if $eumm gt '6.98';
-		  ok($content =~ author_makefile_re("Olivier Mengu\xE9"), 'has one author');
-    }
+		
+    	TODO: {
+      		local $TODO = 'EUMM 7.00 fixed unicode but we have not' if $eumm gt '6.98';
+	  		ok($content =~ author_makefile_re("Olivier Mengué"), 'has one author');
+    	}
+
 		my $metafile = file('META.yml');
 		ok(-f $metafile);
 		my $meta = Parse::CPAN::Meta::LoadFile($metafile);
-		is_deeply($meta->{author}, [q(Olivier Mengu\xE9)]);
+		is_deeply($meta->{author}, [q(Olivier Mengué)], "Author looks good");
 		ok( kill_dist(), 'kill_dist' );
 	}
 }

--- a/t/31_add_metadata.t
+++ b/t/31_add_metadata.t
@@ -6,19 +6,23 @@ BEGIN {
     $^W = 1;
 }
 
+
 use Test::More;
 use t::lib::Test;
 use YAML::Tiny;
 
-plan tests => 5;
+plan tests => 6;
 
 SCOPE: {
-    ok( create_dist('Foo', { 'Makefile.PL' => <<"END_DSL" }), 'create_dist Foo');
+    no utf8;
+    ok( create_dist('Foo', { 'Makefile.PL' => <<'END_DSL' }), 'create_dist Foo');
+use utf8;
 use inc::Module::Install;
 name          'Foo';
 perl_version  '5.005';
 all_from      'lib/Foo.pm';
 add_metadata  'x_foo' => 'bar';
+add_metadata  'x_contributors' => ['Alberto Simões <ambs@cpan.org>'];
 WriteAll;
 END_DSL
 
@@ -27,5 +31,9 @@ END_DSL
     ok( -f $file);
     my $yaml = YAML::Tiny::LoadFile($file);
     ok( $yaml->{x_foo} && $yaml->{x_foo} eq 'bar' );
+    
+    use utf8;
+    my $test_string = 'Alberto Simões <ambs@cpan.org>';
+    ok( ($yaml->{x_contributors}[0] || "") eq $test_string);
     ok( kill_dist(), 'kill_dist' );
 }


### PR DESCRIPTION
This is a first try fixing a utf8 problem from #37.
This is not really a pull request, but a request for comments. This solves the issue, but will only work for perl >= 5.8.1

What happens is that when Perl reads the Makefile.PL, with utf8, it will store strings as utf8. Then, you will not be able to write them as bytes, unless you perform the right conversion.

btw, this is a Pull Request Challenge PR.