### PR TITLE
add . to inc for tests

### DIFF
--- a/t/01_compile.t
+++ b/t/01_compile.t
@@ -14,6 +14,7 @@ use Test::More tests => 68;
 ok( $] >= 5.005, "Your perl is new enough" );
 
 # Load the test class
+use if $INC[-1] ne '.', 'lib', '.';
 use_ok( 't::lib::Test' );
 
 my @classes = qw{

--- a/t/02_mymeta.t
+++ b/t/02_mymeta.t
@@ -18,6 +18,7 @@ if ( $eumm < 6.5702 ) {
 
 
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 # Regular build

--- a/t/05_share.t
+++ b/t/05_share.t
@@ -9,6 +9,7 @@ BEGIN {
 }
 
 use Test::More;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 plan tests => 22;

--- a/t/06_ppport.t
+++ b/t/06_ppport.t
@@ -10,6 +10,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 eval "require Devel::PPPort";

--- a/t/08_dsl.t
+++ b/t/08_dsl.t
@@ -9,6 +9,7 @@ BEGIN {
 }
 
 use Test::More tests => 8;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 # Load the DSL module

--- a/t/09_read.t
+++ b/t/09_read.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 plan tests => 7;

--- a/t/10_test.t
+++ b/t/10_test.t
@@ -7,6 +7,7 @@ BEGIN {
 }
 
 use Test::More;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 use YAML::Tiny ();
 

--- a/t/12_eumm_params.t
+++ b/t/12_eumm_params.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More tests => 11;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 require ExtUtils::MakeMaker;
 use vars qw{ $PREREQ_PM $MIN_PERL_VERSION $BUILD_REQUIRES };

--- a/t/13_author_tests.t
+++ b/t/13_author_tests.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 plan tests => 15;

--- a/t/13_author_tests_ext.t
+++ b/t/13_author_tests_ext.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 eval "require Module::Install::AuthorTests";

--- a/t/13_author_tests_ext2.t
+++ b/t/13_author_tests_ext2.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 eval "use Module::Install::ExtraTests 0.007";

--- a/t/14_auto_include_deps_with_version.t
+++ b/t/14_auto_include_deps_with_version.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 require ExtUtils::MakeMaker;
 use vars qw{ $PREREQ_PM $MIN_PERL_VERSION $BUILD_REQUIRES };

--- a/t/15_wrong_usage.t
+++ b/t/15_wrong_usage.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 plan tests => 4;

--- a/t/16_require.t
+++ b/t/16_require.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 plan tests => 1;

--- a/t/17_sign.t
+++ b/t/17_sign.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 require ExtUtils::MakeMaker;
 

--- a/t/18_all_from.t
+++ b/t/18_all_from.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 require ExtUtils::MakeMaker;
 

--- a/t/19_authors.t
+++ b/t/19_authors.t
@@ -9,6 +9,7 @@ BEGIN {
 use Test::More;
 use File::Spec;
 use Parse::CPAN::Meta;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 plan tests => 32;

--- a/t/20_authors_with_special_characters.t
+++ b/t/20_authors_with_special_characters.t
@@ -9,6 +9,7 @@ BEGIN {
 use Test::More;
 use File::Spec;
 use Parse::CPAN::Meta;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 plan tests => 26;

--- a/t/21_makemaker_args.t
+++ b/t/21_makemaker_args.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 plan tests => 45;

--- a/t/22_installdirs.t
+++ b/t/22_installdirs.t
@@ -9,6 +9,7 @@ BEGIN {
 use Test::More;
 use File::Spec;
 use Parse::CPAN::Meta;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 plan tests => 24;

--- a/t/23_pl_files.t
+++ b/t/23_pl_files.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 plan tests => 35;

--- a/t/25_perl_version_from.t
+++ b/t/25_perl_version_from.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 use Parse::CPAN::Meta;
 

--- a/t/26_unknown_func.t
+++ b/t/26_unknown_func.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 plan tests => 18;

--- a/t/27_build_requires_and_include.t
+++ b/t/27_build_requires_and_include.t
@@ -9,6 +9,7 @@ BEGIN {
 use Test::More;
 use File::Spec;
 use YAML::Tiny;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 plan tests => 14;

--- a/t/28_makemaker_args.t
+++ b/t/28_makemaker_args.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 
 plan tests => 6;

--- a/t/29_requires_from.t
+++ b/t/29_requires_from.t
@@ -7,6 +7,7 @@ BEGIN {
 }
 
 use Test::More;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 require ExtUtils::MakeMaker;
 use vars qw{ $PREREQ_PM $MIN_PERL_VERSION $BUILD_REQUIRES };

--- a/t/30_build_subdirs.t
+++ b/t/30_build_subdirs.t
@@ -7,6 +7,7 @@ BEGIN {
 }
 
 use Test::More;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 use YAML::Tiny;
 

--- a/t/31_add_metadata.t
+++ b/t/31_add_metadata.t
@@ -7,6 +7,7 @@ BEGIN {
 }
 
 use Test::More;
+use if $INC[-1] ne '.', 'lib', '.';
 use t::lib::Test;
 use YAML::Tiny;
 


### PR DESCRIPTION
This makes M::I installable on a Perl where . is not in `@INC`