### PR TITLE
remove dependency on '.' being in @INC

### DIFF
--- a/t/01_compile.t
+++ b/t/01_compile.t
@@ -14,7 +14,8 @@ use Test::More tests => 68;
 ok( $] >= 5.005, "Your perl is new enough" );
 
 # Load the test class
-use_ok( 't::lib::Test' );
+use lib 't/lib';
+use_ok( 'MyTest' );
 
 my @classes = qw{
 	Module::Install::Base
@@ -59,7 +60,7 @@ foreach my $class ( @classes ) {
 	no strict 'refs';
 	is(
 		${"${class}::VERSION"},
-		$t::lib::Test::VERSION,
+		$MyTest::VERSION,
 		"$class \$VERSION matches"
 	);
 }

--- a/t/02_mymeta.t
+++ b/t/02_mymeta.t
@@ -18,7 +18,8 @@ if ( $eumm < 6.5702 ) {
 
 
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 # Regular build
 SCOPE: {

--- a/t/05_share.t
+++ b/t/05_share.t
@@ -9,7 +9,8 @@ BEGIN {
 }
 
 use Test::More;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 plan tests => 22;
 

--- a/t/06_ppport.t
+++ b/t/06_ppport.t
@@ -10,7 +10,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 eval "require Devel::PPPort";
 plan skip_all => 'requires Devel::PPPort' if $@;

--- a/t/08_dsl.t
+++ b/t/08_dsl.t
@@ -9,7 +9,8 @@ BEGIN {
 }
 
 use Test::More tests => 8;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 # Load the DSL module
 require_ok( 'inc::Module::Install::DSL' );

--- a/t/09_read.t
+++ b/t/09_read.t
@@ -8,14 +8,16 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 plan tests => 7;
 
 SCOPE: {
 	ok( create_dist('Foo'), 'create_dist' );
 	ok( build_dist(), 'built dist' );
-	require_ok( file('inc/Module/Install.pm') );
+	use lib dir();
+	require_ok( 'inc/Module/Install.pm' );
 
 	my $file = file('lib/Foo.pm');
 	ok( -f $file, "Found test file '$file'" );

--- a/t/10_test.t
+++ b/t/10_test.t
@@ -7,7 +7,8 @@ BEGIN {
 }
 
 use Test::More;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 use YAML::Tiny ();
 
 plan tests => 14;

--- a/t/12_eumm_params.t
+++ b/t/12_eumm_params.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More tests => 11;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 require ExtUtils::MakeMaker;
 use vars qw{ $PREREQ_PM $MIN_PERL_VERSION $BUILD_REQUIRES };
 

--- a/t/13_author_tests.t
+++ b/t/13_author_tests.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 plan tests => 15;
 

--- a/t/13_author_tests_ext.t
+++ b/t/13_author_tests_ext.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 eval "require Module::Install::AuthorTests";
 plan skip_all => "requires Module::Install::AuthorTests" if $@;

--- a/t/13_author_tests_ext2.t
+++ b/t/13_author_tests_ext2.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 eval "use Module::Install::ExtraTests 0.007";
 plan skip_all => "requires Module::Install::ExtraTests 0.007" if $@;

--- a/t/14_auto_include_deps_with_version.t
+++ b/t/14_auto_include_deps_with_version.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 require ExtUtils::MakeMaker;
 use vars qw{ $PREREQ_PM $MIN_PERL_VERSION $BUILD_REQUIRES };
 

--- a/t/15_wrong_usage.t
+++ b/t/15_wrong_usage.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 plan tests => 4;
 

--- a/t/16_require.t
+++ b/t/16_require.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 plan tests => 1;
 

--- a/t/17_sign.t
+++ b/t/17_sign.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 require ExtUtils::MakeMaker;
 
 plan skip_all => 'test requires ExtUtils::MakeMaker >= 6.17' if eval($ExtUtils::MakeMaker::VERSION) < 6.17;

--- a/t/18_all_from.t
+++ b/t/18_all_from.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 require ExtUtils::MakeMaker;
 
 my $eumm = eval $ExtUtils::MakeMaker::VERSION;

--- a/t/19_authors.t
+++ b/t/19_authors.t
@@ -9,7 +9,8 @@ BEGIN {
 use Test::More;
 use File::Spec;
 use Parse::CPAN::Meta;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 plan tests => 32;
 

--- a/t/20_authors_with_special_characters.t
+++ b/t/20_authors_with_special_characters.t
@@ -9,7 +9,8 @@ BEGIN {
 use Test::More;
 use File::Spec;
 use Parse::CPAN::Meta;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 plan tests => 26;
 

--- a/t/21_makemaker_args.t
+++ b/t/21_makemaker_args.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 plan tests => 45;
 

--- a/t/22_installdirs.t
+++ b/t/22_installdirs.t
@@ -9,7 +9,8 @@ BEGIN {
 use Test::More;
 use File::Spec;
 use Parse::CPAN::Meta;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 plan tests => 24;
 

--- a/t/23_pl_files.t
+++ b/t/23_pl_files.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 plan tests => 35;
 

--- a/t/25_perl_version_from.t
+++ b/t/25_perl_version_from.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 use Parse::CPAN::Meta;
 
 plan tests => 36;

--- a/t/26_unknown_func.t
+++ b/t/26_unknown_func.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 plan tests => 18;
 

--- a/t/27_build_requires_and_include.t
+++ b/t/27_build_requires_and_include.t
@@ -9,7 +9,8 @@ BEGIN {
 use Test::More;
 use File::Spec;
 use YAML::Tiny;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 plan tests => 14;
 

--- a/t/28_makemaker_args.t
+++ b/t/28_makemaker_args.t
@@ -8,7 +8,8 @@ BEGIN {
 
 use Test::More;
 use File::Spec;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 
 plan tests => 6;
 

--- a/t/29_requires_from.t
+++ b/t/29_requires_from.t
@@ -7,7 +7,8 @@ BEGIN {
 }
 
 use Test::More;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 require ExtUtils::MakeMaker;
 use vars qw{ $PREREQ_PM $MIN_PERL_VERSION $BUILD_REQUIRES };
 

--- a/t/30_build_subdirs.t
+++ b/t/30_build_subdirs.t
@@ -7,7 +7,8 @@ BEGIN {
 }
 
 use Test::More;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 use YAML::Tiny;
 
 plan tests => 20 * 2;

--- a/t/31_add_metadata.t
+++ b/t/31_add_metadata.t
@@ -7,7 +7,8 @@ BEGIN {
 }
 
 use Test::More;
-use t::lib::Test;
+use lib 't/lib';
+use MyTest;
 use YAML::Tiny;
 
 plan tests => 5;

--- a/t/lib/MyTest.pm
+++ b/t/lib/MyTest.pm
@@ -1,4 +1,4 @@
-package t::lib::Test;
+package MyTest;
 
 use strict;
 use File::Spec   ();


### PR DESCRIPTION
This is an alternative to #57 suggested by @haarg.

Perl 5.25.7 has the option of not including '.' in `@INC` by default.  This should rework M::I so that its tests pass under this configuration.  t/lib is added to `@INC` for the test suite where needed, and Test.pm has been renamed to MyTest.pm so that it is not confused with the Test.pm that comes with Perl.

I am happy to change `MyTest.pm` in the event a better name can be thought of.

Of notable difference from #57 is `t/09_read.t` which now adds `dir()` to `@INC`.  This is necessary as to find `inc/Module/Install.pm`, although there may be a "better" way.

```perl
        use lib dir();
        require_ok( 'inc/Module/Install.pm' );
```